### PR TITLE
Handle invalid JSON in localStorage for gameCart and gameWishlist

### DIFF
--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -15,17 +15,26 @@ export const GameProvider = ({ children }) => {
   const [wishlistItems, setWishlistItems] = useState([]);
 
   // Load from localStorage on mount
-  useEffect(() => {
+useEffect(() => {
+  try {
     const savedCart = localStorage.getItem('gameCart');
-    const savedWishlist = localStorage.getItem('gameWishlist');
-    
     if (savedCart) {
       setCartItems(JSON.parse(savedCart));
     }
+  } catch (err) {
+    console.warn("Error parsing gameCart from localStorage", err);
+  }
+
+  try {
+    const savedWishlist = localStorage.getItem('gameWishlist');
     if (savedWishlist) {
       setWishlistItems(JSON.parse(savedWishlist));
     }
-  }, []);
+  } catch (err) {
+    console.warn("Error parsing gameWishlist from localStorage", err);
+  }
+}, []);
+
 
   // Save to localStorage whenever state changes
   useEffect(() => {


### PR DESCRIPTION
Wrapped JSON.parse in try-catch in GameProvider to prevent app crashes from corrupt localStorage values.
